### PR TITLE
In merge dialog also Start-ID should be searched

### DIFF
--- a/src/net/geco/model/impl/RunnerImpl.java
+++ b/src/net/geco/model/impl/RunnerImpl.java
@@ -78,7 +78,7 @@ public class RunnerImpl extends AbstractRunnerImpl implements Runner {
 
 	@Override
 	public String toString() {
-		return getNameR() + ", " + getEcard() + ", " + getCourse().getName(); //$NON-NLS-1$ //$NON-NLS-2$
+		return getStartId() + ", "+  getNameR() + ", " + getEcard() + ", " + getCourse().getName(); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 	
 	public String idString() {


### PR DESCRIPTION
In some school events, when renting 200-500 si-cards, we give to every
runner a random si-card, but a specific start number. At the read out
place, when then fill in the start number the runner is wearing. So it
would be nice if in Geco in the merge dialog you could also search after
the start number.
